### PR TITLE
Return error when repo input has slash in it to prevent user issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ if (!fs.existsSync(inputPath)) {
   return
 }
 
+if (inputRepo.indexOf('/') !== -1) {
+  core.setFailed(`inputRepo cannot contain any slashes use the owner parameter to indicate the owner`)
+  return
+}
+
 async function createBranchIfNotExists() {
   let branchResult = await checkBranch({
     Authorization: `Bearer ${core.getInput('access-token')}`,


### PR DESCRIPTION
I had a configuration error when I injected `repo: ${{ github.repository }}` as a parameter. That contains the owner and a slash in front of the repositoryname. The error was not descriptive (NotFound iirc). Took me a while to find the issue.

This change alerts the user when the repository parameter contains a slash character.